### PR TITLE
Fix async handling of files PLAT-570

### DIFF
--- a/gateway/clients.py
+++ b/gateway/clients.py
@@ -4,7 +4,6 @@ from typing import Any, Dict, Tuple
 
 import requests
 import aiohttp
-from aiohttp import ContentTypeError
 from django.http.request import QueryDict
 from bravado_core.spec import Spec
 from rest_framework.request import Request
@@ -172,8 +171,9 @@ class AsyncSwaggerClient(BaseSwaggerClient):
             async with method(url, data=data, headers=self.get_headers()) as response:
                 try:
                     content = await response.json()
-                except (json.JSONDecodeError, ContentTypeError):
-                    content = await response.content.read()
+                except (json.JSONDecodeError, aiohttp.ContentTypeError):
+                    content = await response.read()
+
             return_data = (content, response.status, response.headers)
 
         # Cache data if request is cache-valid

--- a/gateway/tests/utils.py
+++ b/gateway/tests/utils.py
@@ -34,6 +34,10 @@ class AiohttpResponseMock:
         return stream
 
     @asyncio.coroutine
+    def read(self):
+        return self.content.read()
+
+    @asyncio.coroutine
     def text(self, encoding='utf-8'):
         return self.body.decode(encoding)
 


### PR DESCRIPTION
## Purpose
Sending and retrieving files the async gateway caused errors or was not possible.

## Approach
Extended `AsyncSwaggerClient.request()` for handling file requests.

### Further Info
https://humanitec.atlassian.net/browse/PLAT-526
https://humanitec.atlassian.net/browse/PLAT-570
